### PR TITLE
Transforma NotificationSettingsCard em seletor de horário

### DIFF
--- a/.github/workflows/publish-apk.yml
+++ b/.github/workflows/publish-apk.yml
@@ -1,0 +1,40 @@
+name: Build and publish APK
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Copy APK to stable download path
+        run: |
+          mkdir -p app/release
+          cp app/build/outputs/apk/debug/app-debug.apk app/release/app-release.apk
+
+      - name: Commit APK to repository
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'ci: update downloadable APK [skip ci]'
+          file_pattern: app/release/app-release.apk

--- a/APK_DOWNLOAD.md
+++ b/APK_DOWNLOAD.md
@@ -1,0 +1,21 @@
+# Download do APK via Internet
+
+Este repositório agora possui uma GitHub Action para gerar um APK e publicar em um caminho fixo no branch.
+
+## Como gerar
+
+1. Vá em **Actions** no GitHub.
+2. Execute o workflow **Build and publish APK** manualmente.
+3. Ao final, ele salva o arquivo em `app/release/app-release.apk` no branch atual.
+
+## URL de download
+
+Depois da execução, você poderá baixar em:
+
+`https://raw.githubusercontent.com/<OWNER>/<REPO>/<BRANCH>/app/release/app-release.apk`
+
+Exemplo de formato:
+
+`https://raw.githubusercontent.com/Luminary-Team/eden-mobile/refs/heads/main/app/release/app-release.apk`
+
+> Observação: o workflow gera a variante **debug** (`assembleDebug`) para garantir instalação fácil sem configuração de assinatura de release.

--- a/app/src/main/java/com/will/busnotification/data/dto/NotificationSetupPayload.kt
+++ b/app/src/main/java/com/will/busnotification/data/dto/NotificationSetupPayload.kt
@@ -1,0 +1,12 @@
+package com.will.busnotification.data.dto
+
+import com.will.busnotification.data.model.NotificationWindow
+
+data class NotificationSetupPayload(
+    val lineCode: String,
+    val lineName: String,
+    val departureStop: String,
+    val arrivalStop: String,
+    val destination: String,
+    val notificationWindow: NotificationWindow
+)

--- a/app/src/main/java/com/will/busnotification/data/dto/RouteRequest.kt
+++ b/app/src/main/java/com/will/busnotification/data/dto/RouteRequest.kt
@@ -1,5 +1,7 @@
 package com.will.busnotification.data.dto
 
+import java.time.LocalDate
+
 /**
  * Requisição para a Google Routes API
  * @param origin Localização de origem (endereço ou coordenadas)
@@ -12,6 +14,7 @@ data class RouteRequest(
     val origin: AdressRequest,
     val destination: AdressRequest,
     val travelMode: String = "TRANSIT",
+    val departureTime: String? = "${LocalDate.now()}T8:00:00Z",
     val computeAlternativeRoutes: Boolean = true,
     val transitPreferences: TransitPreferences? = null
 )

--- a/app/src/main/java/com/will/busnotification/data/dto/RouteResponse.kt
+++ b/app/src/main/java/com/will/busnotification/data/dto/RouteResponse.kt
@@ -1,15 +1,15 @@
 package com.will.busnotification.data.dto
 
 data class RouteResponse(
-    val routes: List<Route>
+    val routes: List<Route>?
 )
 
 data class Route(
-    val legs: List<Leg>
+    val legs: List<Leg>?
 )
 
 data class Leg(
-    val steps: List<Step>
+    val steps: List<Step>?
 )
 
 data class Step(
@@ -33,7 +33,16 @@ data class StopDetails(
 
 data class StopInfo(
     val name: String,
-    val location: String
+    val location: Location
+)
+
+data class Location(
+    val latLng: LatLng
+)
+
+data class LatLng(
+    val latitude: Double,
+    val longitude: Double
 )
 
 data class LocalizedValues(
@@ -56,7 +65,7 @@ data class TransitLine(
     val headsign: String?,
     val color: String,
     val textColor: String,
-    val agencies: List<Agency>,
+    val agencies: List<Agency>?,
     val vehicle: Vehicle
 )
 

--- a/app/src/main/java/com/will/busnotification/data/model/NotificationWindow.kt
+++ b/app/src/main/java/com/will/busnotification/data/model/NotificationWindow.kt
@@ -1,0 +1,9 @@
+package com.will.busnotification.data.model
+
+data class NotificationWindow(
+    val startHour: Int,
+    val startMinute: Int,
+    val endHour: Int,
+    val endMinute: Int
+)
+

--- a/app/src/main/java/com/will/busnotification/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/will/busnotification/navigation/AppNavHost.kt
@@ -7,7 +7,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.will.busnotification.ui.AddNotificationScreen
+import com.will.busnotification.ui.SearchLineScreen
 import com.will.busnotification.ui.HomeScreen
 import com.will.busnotification.ui.NotificationHistoryScreen
 import com.will.busnotification.ui.SetupNotificationScreen
@@ -19,16 +19,17 @@ fun AppNavHost(navController: NavHostController = rememberNavController()) {
         startDestination = "home"
     ) {
         composable("home") { HomeScreen(navController) }
-        composable("addBuss") { AddNotificationScreen(navController) }
+        composable("addBuss") { SearchLineScreen(navController) }
         composable("notificationHistory") { NotificationHistoryScreen(navController) }
         composable(
-            "notificationSetup/{lineCode}/{lineName}/{departureStop}/{arrivalStop}/{arrivalTime}",
+            "notificationSetup/{lineCode}/{lineName}/{departureStop}/{arrivalStop}/{arrivalTime}/{headsign}",
             arguments = listOf(
                 navArgument("lineCode") { type = NavType.StringType },
                 navArgument("lineName") { type = NavType.StringType },
                 navArgument("departureStop") { type = NavType.StringType },
                 navArgument("arrivalStop") { type = NavType.StringType },
                 navArgument("arrivalTime") { type = NavType.StringType },
+                navArgument("headsign") { type = NavType.StringType },
             )
         ) { backStackEntry ->
             val arguments = backStackEntry.arguments
@@ -38,7 +39,8 @@ fun AppNavHost(navController: NavHostController = rememberNavController()) {
                 lineName = arguments?.getString("lineName"),
                 departureStop = arguments?.getString("departureStop"),
                 arrivalStop = arguments?.getString("arrivalStop"),
-                arrivalTime = arguments?.getString("arrivalTime")
+                arrivalTime = arguments?.getString("arrivalTime"),
+                destination = arguments?.getString("headsign")
             )
         }
     }

--- a/app/src/main/java/com/will/busnotification/repository/RouteMapper.kt
+++ b/app/src/main/java/com/will/busnotification/repository/RouteMapper.kt
@@ -3,15 +3,16 @@ package com.will.busnotification.repository
 import android.graphics.Color
 import com.will.busnotification.data.dto.RouteResponse
 import com.will.busnotification.data.model.Bus
+import androidx.core.graphics.toColorInt
 
 
 fun RouteResponse.toBusList(): List<Bus> {
-    return routes.mapNotNull { route ->
-        val step = route.legs.firstOrNull()?.steps?.firstOrNull { it.transitDetails != null }
+    return routes?.mapNotNull { route ->
+        val step = route.legs?.firstOrNull()?.steps?.firstOrNull { it.transitDetails != null }
         val details = step?.transitDetails ?: return@mapNotNull null
 
-        val colorInt = runCatching { Color.parseColor(details.transitLine.color) }.getOrDefault(Color.BLACK)
-        val textColorInt = runCatching { Color.parseColor(details.transitLine.textColor) }.getOrDefault(Color.WHITE)
+        val colorInt = runCatching { details.transitLine.color.toColorInt() }.getOrDefault(Color.BLACK)
+        val textColorInt = runCatching { details.transitLine.textColor.toColorInt() }.getOrDefault(Color.WHITE)
 
         Bus(
             lineName = details.transitLine.name,
@@ -24,5 +25,5 @@ fun RouteResponse.toBusList(): List<Bus> {
             color = colorInt,
             textColor = textColorInt
         )
-    }
+    } ?: emptyList()
 }

--- a/app/src/main/java/com/will/busnotification/ui/HomeScreen.kt
+++ b/app/src/main/java/com/will/busnotification/ui/HomeScreen.kt
@@ -35,7 +35,7 @@ fun HomeScreen(
     val buses by viewModel.busList.collectAsState()
 
     LaunchedEffect(Unit) {
-        viewModel.loadBus()
+        viewModel.loadBusFromFirebase()
     }
 
     Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/will/busnotification/ui/SearchLineScreen.kt
+++ b/app/src/main/java/com/will/busnotification/ui/SearchLineScreen.kt
@@ -34,15 +34,15 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.will.busnotification.ui.components.HeaderComponent
-import com.will.busnotification.viewmodel.AddBusViewModel
+import com.will.busnotification.viewmodel.SearchLineViewModel
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddNotificationScreen(
+fun SearchLineScreen(
     navController: NavHostController,
-    viewModel: AddBusViewModel = hiltViewModel()
+    viewModel: SearchLineViewModel = hiltViewModel()
 ) {
     val searchQuery by viewModel.searchQuery.collectAsState()
     val searchResults by viewModel.searchResults.collectAsState()
@@ -86,7 +86,7 @@ fun AddNotificationScreen(
                                     val encodedLineName = URLEncoder.encode(place.lineName, StandardCharsets.UTF_8.toString())
                                     val encodedDepartureStop = URLEncoder.encode(place.departureStop, StandardCharsets.UTF_8.toString())
                                     val encodedArrivalStop = URLEncoder.encode(place.arrivalStop, StandardCharsets.UTF_8.toString())
-                                    navController.navigate("notificationSetup/${place.lineCode}/$encodedLineName/$encodedDepartureStop/$encodedArrivalStop/${place.arrivalTime}")
+                                    navController.navigate("notificationSetup/${place.lineCode}/$encodedLineName/$encodedDepartureStop/$encodedArrivalStop/${place.arrivalTime}/${place.headsign}")
                                 },
                             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
                             elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
@@ -121,7 +121,7 @@ fun AddNotificationScreen(
 
 @Preview(showBackground = true)
 @Composable
-fun AddNotificationScreenPreview() {
+fun SearchLineScreenPreview() {
     // Nota: O preview não fará chamadas de API reais.
-    AddNotificationScreen(navController = rememberNavController())
+    SearchLineScreen(navController = rememberNavController())
 }

--- a/app/src/main/java/com/will/busnotification/ui/SetupNotificationScreen.kt
+++ b/app/src/main/java/com/will/busnotification/ui/SetupNotificationScreen.kt
@@ -19,13 +19,13 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.will.busnotification.data.dto.NotificationSetupPayload
 import com.will.busnotification.data.model.NotificationWindow
 import com.will.busnotification.ui.components.BusInfoCard
 import com.will.busnotification.ui.components.HeaderComponent
 import com.will.busnotification.ui.components.NotificationSettingsCard
 import com.will.busnotification.ui.components.RemovePointButton
 import com.will.busnotification.ui.components.SaveChangesButton
-import com.will.busnotification.viewmodel.NotificationSetupPayload
 import com.will.busnotification.viewmodel.NotificationSetupViewModel
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
@@ -37,13 +37,15 @@ fun SetupNotificationScreen(
     lineName: String?,
     departureStop: String?,
     arrivalStop: String?,
-    arrivalTime: String?
+    arrivalTime: String?,
+    destination: String?
 ) {
     val notificationSetupViewModel: NotificationSetupViewModel = viewModel()
 
     val decodedLineName = lineName?.let { URLDecoder.decode(it, StandardCharsets.UTF_8.toString()) }
     val decodedDepartureStop = departureStop?.let { URLDecoder.decode(it, StandardCharsets.UTF_8.toString()) }
     val decodedArrivalStop = arrivalStop?.let { URLDecoder.decode(it, StandardCharsets.UTF_8.toString()) }
+    val decodedDestination = destination?.let { URLDecoder.decode(it, StandardCharsets.UTF_8.toString()) }
 
     var selectedWindow by remember { mutableStateOf(NotificationWindow(8, 0, 18, 0)) }
 
@@ -78,10 +80,15 @@ fun SetupNotificationScreen(
                         lineName = decodedLineName.orEmpty(),
                         departureStop = decodedDepartureStop.orEmpty(),
                         arrivalStop = decodedArrivalStop.orEmpty(),
+                        destination = decodedDestination.orEmpty(),
                         notificationWindow = selectedWindow
                     )
 
                     notificationSetupViewModel.saveNotificationSetup(payload)
+
+                    navController.navigate("home") {
+                        popUpTo("home") { inclusive = true }
+                    }
                 }
             )
             Spacer(modifier = Modifier.height(8.dp))
@@ -100,6 +107,7 @@ fun SetupNotificationScreenPreview() {
         lineName = "Rua Willamy Ricardo Pinatto Andreotti",
         departureStop = "ponto 1",
         arrivalStop = "ponto 2",
-        arrivalTime = "06:16"
+        arrivalTime = "06:16",
+        destination = "Lapa"
     )
 }

--- a/app/src/main/java/com/will/busnotification/ui/SetupNotificationScreen.kt
+++ b/app/src/main/java/com/will/busnotification/ui/SetupNotificationScreen.kt
@@ -7,18 +7,26 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.will.busnotification.data.model.NotificationWindow
 import com.will.busnotification.ui.components.BusInfoCard
 import com.will.busnotification.ui.components.HeaderComponent
 import com.will.busnotification.ui.components.NotificationSettingsCard
 import com.will.busnotification.ui.components.RemovePointButton
 import com.will.busnotification.ui.components.SaveChangesButton
+import com.will.busnotification.viewmodel.NotificationSetupPayload
+import com.will.busnotification.viewmodel.NotificationSetupViewModel
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
@@ -31,9 +39,13 @@ fun SetupNotificationScreen(
     arrivalStop: String?,
     arrivalTime: String?
 ) {
+    val notificationSetupViewModel: NotificationSetupViewModel = viewModel()
+
     val decodedLineName = lineName?.let { URLDecoder.decode(it, StandardCharsets.UTF_8.toString()) }
     val decodedDepartureStop = departureStop?.let { URLDecoder.decode(it, StandardCharsets.UTF_8.toString()) }
     val decodedArrivalStop = arrivalStop?.let { URLDecoder.decode(it, StandardCharsets.UTF_8.toString()) }
+
+    var selectedWindow by remember { mutableStateOf(NotificationWindow(8, 0, 18, 0)) }
 
     Column(
         modifier = Modifier
@@ -54,9 +66,24 @@ fun SetupNotificationScreen(
         ) {
             BusInfoCard(lineCode, decodedLineName, decodedDepartureStop, decodedArrivalStop, arrivalTime)
             Spacer(modifier = Modifier.height(16.dp))
-            NotificationSettingsCard()
+            NotificationSettingsCard(
+                initialWindow = selectedWindow,
+                onNotificationWindowChanged = { selectedWindow = it }
+            )
             Spacer(modifier = Modifier.weight(1f))
-            SaveChangesButton()
+            SaveChangesButton(
+                onClick = {
+                    val payload = NotificationSetupPayload(
+                        lineCode = lineCode.orEmpty(),
+                        lineName = decodedLineName.orEmpty(),
+                        departureStop = decodedDepartureStop.orEmpty(),
+                        arrivalStop = decodedArrivalStop.orEmpty(),
+                        notificationWindow = selectedWindow
+                    )
+
+                    notificationSetupViewModel.saveNotificationSetup(payload)
+                }
+            )
             Spacer(modifier = Modifier.height(8.dp))
             RemovePointButton()
         }

--- a/app/src/main/java/com/will/busnotification/ui/components/SetupNotificationComponents.kt
+++ b/app/src/main/java/com/will/busnotification/ui/components/SetupNotificationComponents.kt
@@ -1,6 +1,7 @@
 package com.will.busnotification.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,10 +18,14 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TimePickerState
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,6 +39,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import java.util.Locale
 
 @Composable
 fun BusInfoCard(
@@ -80,51 +86,75 @@ fun BusInfoCard(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationSettingsCard() {
-    var onlyWeekdays by remember { mutableStateOf(true) }
-    var lessThan10min by remember { mutableStateOf(false) }
+    var selectedHour by remember { mutableStateOf(8) }
+    var selectedMinute by remember { mutableStateOf(0) }
+    var showTimePicker by remember { mutableStateOf(false) }
+
+    val selectedTime = String.format(Locale.getDefault(), "%02d:%02d", selectedHour, selectedMinute)
 
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(Color(0xFFE0EAFC))
+            .clickable { showTimePicker = true }
             .padding(16.dp)
     ) {
-        Text("Receber notificações entre", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
-        Spacer(modifier = Modifier.height(16.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceAround,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            TimeSelector(time = "00:00")
-            Text(text = "-", fontSize = 24.sp)
-            TimeSelector(time = "00:00")
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        HorizontalDivider(thickness = 1.dp, color = Color.LightGray)
-        Spacer(modifier = Modifier.height(16.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(
-                checked = onlyWeekdays,
-                onCheckedChange = { onlyWeekdays = it }
-            )
-            Column {
-                Text("Somente dias úteis")
-                Text("Segunda à sexta", style = MaterialTheme.typography.bodySmall)
-            }
-        }
+        Text("Horário da notificação", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(modifier = Modifier.height(12.dp))
+        TimeSelector(time = selectedTime)
         Spacer(modifier = Modifier.height(8.dp))
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(
-                checked = lessThan10min,
-                onCheckedChange = { lessThan10min = it }
-            )
-            Text("Notificar apenas quando o ônibus estiver a menos de 10min")
-        }
+        Text(
+            text = "Toque no card para escolher o horário",
+            style = MaterialTheme.typography.bodySmall
+        )
     }
+
+    if (showTimePicker) {
+        val timePickerState = rememberTimePickerState(
+            initialHour = selectedHour,
+            initialMinute = selectedMinute,
+            is24Hour = true
+        )
+
+        TimePickerDialog(
+            state = timePickerState,
+            onConfirm = {
+                selectedHour = timePickerState.hour
+                selectedMinute = timePickerState.minute
+                showTimePicker = false
+            },
+            onDismiss = { showTimePicker = false }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TimePickerDialog(
+    state: TimePickerState,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text("Confirmar")
+            }
+        },
+        dismissButton = {
+            Button(onClick = onDismiss) {
+                Text("Cancelar")
+            }
+        },
+        text = {
+            TimePicker(state = state)
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/will/busnotification/ui/components/SetupNotificationComponents.kt
+++ b/app/src/main/java/com/will/busnotification/ui/components/SetupNotificationComponents.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -92,10 +93,10 @@ fun NotificationSettingsCard(
     initialWindow: NotificationWindow = NotificationWindow(8, 0, 18, 0),
     onNotificationWindowChanged: (NotificationWindow) -> Unit = {}
 ) {
-    var startHour by remember { mutableStateOf(initialWindow.startHour) }
-    var startMinute by remember { mutableStateOf(initialWindow.startMinute) }
-    var endHour by remember { mutableStateOf(initialWindow.endHour) }
-    var endMinute by remember { mutableStateOf(initialWindow.endMinute) }
+    var startHour by remember { mutableIntStateOf(initialWindow.startHour) }
+    var startMinute by remember { mutableIntStateOf(initialWindow.startMinute) }
+    var endHour by remember { mutableIntStateOf(initialWindow.endHour) }
+    var endMinute by remember { mutableIntStateOf(initialWindow.endMinute) }
 
     var showTimePicker by remember { mutableStateOf(false) }
     var editingStartTime by remember { mutableStateOf(true) }

--- a/app/src/main/java/com/will/busnotification/ui/components/SetupNotificationComponents.kt
+++ b/app/src/main/java/com/will/busnotification/ui/components/SetupNotificationComponents.kt
@@ -17,9 +17,7 @@ import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TimePicker
@@ -27,6 +25,7 @@ import androidx.compose.material3.TimePickerState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.will.busnotification.data.model.NotificationWindow
 import java.util.Locale
 
 @Composable
@@ -88,43 +88,83 @@ fun BusInfoCard(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NotificationSettingsCard() {
-    var selectedHour by remember { mutableStateOf(8) }
-    var selectedMinute by remember { mutableStateOf(0) }
-    var showTimePicker by remember { mutableStateOf(false) }
+fun NotificationSettingsCard(
+    initialWindow: NotificationWindow = NotificationWindow(8, 0, 18, 0),
+    onNotificationWindowChanged: (NotificationWindow) -> Unit = {}
+) {
+    var startHour by remember { mutableStateOf(initialWindow.startHour) }
+    var startMinute by remember { mutableStateOf(initialWindow.startMinute) }
+    var endHour by remember { mutableStateOf(initialWindow.endHour) }
+    var endMinute by remember { mutableStateOf(initialWindow.endMinute) }
 
-    val selectedTime = String.format(Locale.getDefault(), "%02d:%02d", selectedHour, selectedMinute)
+    var showTimePicker by remember { mutableStateOf(false) }
+    var editingStartTime by remember { mutableStateOf(true) }
+
+    val startTime = String.format(Locale.getDefault(), "%02d:%02d", startHour, startMinute)
+    val endTime = String.format(Locale.getDefault(), "%02d:%02d", endHour, endMinute)
+
+    LaunchedEffect(startHour, startMinute, endHour, endMinute) {
+        onNotificationWindowChanged(
+            NotificationWindow(
+                startHour = startHour,
+                startMinute = startMinute,
+                endHour = endHour,
+                endMinute = endMinute
+            )
+        )
+    }
 
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(Color(0xFFE0EAFC))
-            .clickable { showTimePicker = true }
             .padding(16.dp)
     ) {
-        Text("Horário da notificação", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
-        Spacer(modifier = Modifier.height(12.dp))
-        TimeSelector(time = selectedTime)
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "Toque no card para escolher o horário",
-            style = MaterialTheme.typography.bodySmall
-        )
+        Text("Receber notificações entre", fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceAround,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            TimeSelector(
+                time = startTime,
+                onClick = {
+                    editingStartTime = true
+                    showTimePicker = true
+                }
+            )
+
+            Text(text = "-", fontSize = 24.sp)
+
+            TimeSelector(
+                time = endTime,
+                onClick = {
+                    editingStartTime = false
+                    showTimePicker = true
+                }
+            )
+        }
     }
 
     if (showTimePicker) {
         val timePickerState = rememberTimePickerState(
-            initialHour = selectedHour,
-            initialMinute = selectedMinute,
+            initialHour = if (editingStartTime) startHour else endHour,
+            initialMinute = if (editingStartTime) startMinute else endMinute,
             is24Hour = true
         )
 
         TimePickerDialog(
             state = timePickerState,
             onConfirm = {
-                selectedHour = timePickerState.hour
-                selectedMinute = timePickerState.minute
+                if (editingStartTime) {
+                    startHour = timePickerState.hour
+                    startMinute = timePickerState.minute
+                } else {
+                    endHour = timePickerState.hour
+                    endMinute = timePickerState.minute
+                }
                 showTimePicker = false
             },
             onDismiss = { showTimePicker = false }
@@ -158,11 +198,12 @@ private fun TimePickerDialog(
 }
 
 @Composable
-fun TimeSelector(time: String) {
+fun TimeSelector(time: String, onClick: () -> Unit) {
     Box(
         modifier = Modifier
             .clip(RoundedCornerShape(8.dp))
             .background(Color.White)
+            .clickable(onClick = onClick)
             .padding(horizontal = 24.dp, vertical = 12.dp),
         contentAlignment = Alignment.Center
     ) {
@@ -171,9 +212,9 @@ fun TimeSelector(time: String) {
 }
 
 @Composable
-fun SaveChangesButton() {
+fun SaveChangesButton(onClick: () -> Unit) {
     Button(
-        onClick = { /* TODO */ },
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
             .height(50.dp),

--- a/app/src/main/java/com/will/busnotification/viewmodel/BusViewModel.kt
+++ b/app/src/main/java/com/will/busnotification/viewmodel/BusViewModel.kt
@@ -29,48 +29,40 @@ class BusViewModel : ViewModel() {
 
     fun loadBusFromFirebase() {
         val locationsRef = firestore.collection("locations")
-        val originDoc = locationsRef.document("origin")
-        val destDoc = locationsRef.document("destination")
+        val lineInfo = locationsRef.document("297A-10")
 
-        originDoc.get().addOnSuccessListener { originSnap: DocumentSnapshot ->
-            destDoc.get().addOnSuccessListener { destSnap: DocumentSnapshot ->
-                val originAddress = originSnap.getString("address") ?: ""
-                val destAddress = destSnap.getString("address") ?: ""
+        lineInfo.get().addOnSuccessListener { lineSnap: DocumentSnapshot ->
+            val originAddress = lineSnap.getString("departureStop") ?: ""
+            val destAddress = lineSnap.getString("destination") ?: ""
 
-//                // Ajuste aqui os parâmetros de LocationInput conforme sua implementação real.
-//                val originInput = LocationInput(address = originAddress)
-//                val destinationInput = LocationInput(address = destAddress)
-
-                val requestBody = RouteRequest(
-                    origin = AdressRequest(originAddress),
-                    destination = AdressRequest(destAddress),
-                    travelMode = "TRANSIT",
-                    computeAlternativeRoutes = true,
-                    transitPreferences = TransitPreferences(
-                        routingPreference = "TRANSIT_ROUTING_PREFERENCE_UNSPECIFIED",
-                        allowedTravelModes = listOf("BUS")
-                    )
+            val requestBody = RouteRequest(
+                origin = AdressRequest(originAddress),
+                destination = AdressRequest(destAddress),
+                travelMode = "TRANSIT",
+                computeAlternativeRoutes = true,
+                transitPreferences = TransitPreferences(
+                    routingPreference = "TRANSIT_ROUTING_PREFERENCE_UNSPECIFIED",
+                    allowedTravelModes = listOf("BUS")
                 )
+            )
 
-                GoogleApiInstance.retrofit.getBus(requestBody, apiKey = BuildConfig.GOOGLE_API_KEY)
-                    .enqueue(object : Callback<RouteResponse> {
-                        override fun onResponse(call: Call<RouteResponse>, response: Response<RouteResponse>) {
-                            if (response.isSuccessful) {
-                                response.body()?.let {
-                                    _busList.value = it.toBusList()
-                                }
+            GoogleApiInstance.retrofit.getBus(requestBody, apiKey = BuildConfig.GOOGLE_API_KEY)
+                .enqueue(object : Callback<RouteResponse> {
+                    override fun onResponse(call: Call<RouteResponse>, response: Response<RouteResponse>) {
+                        if (response.isSuccessful) {
+                            response.body()?.let {
+                                _busList.value = it.toBusList()
                             }
                         }
+                    }
 
-                        override fun onFailure(p0: Call<RouteResponse>, p1: Throwable) {
-                            p1.message?.let { println(it) }
-                        }
-                    })
-            }.addOnFailureListener { e: Exception ->
-                println("Erro ao ler destination: ${e.message}")
-            }
+                    override fun onFailure(p0: Call<RouteResponse>, p1: Throwable) {
+                        p1.message?.let { println(it) }
+                    }
+                })
+
         }.addOnFailureListener { e: Exception ->
-            println("Erro ao ler origin: ${e.message}")
+            println("Erro ao ler destination: ${e.message}")
         }
     }
 

--- a/app/src/main/java/com/will/busnotification/viewmodel/NotificationSetupViewModel.kt
+++ b/app/src/main/java/com/will/busnotification/viewmodel/NotificationSetupViewModel.kt
@@ -1,0 +1,61 @@
+package com.will.busnotification.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.firestore.ktx.firestore
+import com.will.busnotification.data.model.NotificationWindow
+
+data class NotificationSetupPayload(
+    val lineCode: String,
+    val lineName: String,
+    val departureStop: String,
+    val arrivalStop: String,
+    val notificationWindow: NotificationWindow
+)
+
+interface NotificationScheduleManager {
+    fun scheduleNotificationWindow(payload: NotificationSetupPayload)
+}
+
+class DefaultNotificationScheduleManager : NotificationScheduleManager {
+    override fun scheduleNotificationWindow(payload: NotificationSetupPayload) {
+        // TODO: substituir por integração real com WorkManager para agendamento recorrente.
+        Log.d("NotificationSchedule", "Agendando janela: $payload")
+    }
+}
+
+class NotificationSetupViewModel : ViewModel() {
+
+    private val firestore = Firebase.firestore
+    private val scheduleManager: NotificationScheduleManager = DefaultNotificationScheduleManager()
+
+    fun saveNotificationSetup(
+        payload: NotificationSetupPayload,
+        onSuccess: () -> Unit = {},
+        onError: (Throwable) -> Unit = {}
+    ) {
+        val firestorePayload = mapOf(
+            "lineCode" to payload.lineCode,
+            "lineName" to payload.lineName,
+            "departureStop" to payload.departureStop,
+            "arrivalStop" to payload.arrivalStop,
+            "startHour" to payload.notificationWindow.startHour,
+            "startMinute" to payload.notificationWindow.startMinute,
+            "endHour" to payload.notificationWindow.endHour,
+            "endMinute" to payload.notificationWindow.endMinute,
+            "createdAt" to System.currentTimeMillis()
+        )
+
+        firestore.collection("notification_setups")
+            .add(firestorePayload)
+            .addOnSuccessListener {
+                scheduleManager.scheduleNotificationWindow(payload)
+                onSuccess()
+            }
+            .addOnFailureListener { error ->
+                onError(error)
+            }
+    }
+}
+

--- a/app/src/main/java/com/will/busnotification/viewmodel/NotificationSetupViewModel.kt
+++ b/app/src/main/java/com/will/busnotification/viewmodel/NotificationSetupViewModel.kt
@@ -2,17 +2,9 @@ package com.will.busnotification.viewmodel
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
-import com.google.firebase.ktx.Firebase
 import com.google.firebase.firestore.ktx.firestore
-import com.will.busnotification.data.model.NotificationWindow
-
-data class NotificationSetupPayload(
-    val lineCode: String,
-    val lineName: String,
-    val departureStop: String,
-    val arrivalStop: String,
-    val notificationWindow: NotificationWindow
-)
+import com.google.firebase.ktx.Firebase
+import com.will.busnotification.data.dto.NotificationSetupPayload
 
 interface NotificationScheduleManager {
     fun scheduleNotificationWindow(payload: NotificationSetupPayload)
@@ -44,17 +36,20 @@ class NotificationSetupViewModel : ViewModel() {
             "startMinute" to payload.notificationWindow.startMinute,
             "endHour" to payload.notificationWindow.endHour,
             "endMinute" to payload.notificationWindow.endMinute,
+            "destination" to payload.destination,
             "createdAt" to System.currentTimeMillis()
         )
 
-        firestore.collection("notification_setups")
-            .add(firestorePayload)
+        firestore.collection("locations").document(firestorePayload["lineCode"].toString())
+            .set(firestorePayload)
             .addOnSuccessListener {
                 scheduleManager.scheduleNotificationWindow(payload)
                 onSuccess()
+                Log.d("NotificationSetupViewModel", "Notification setup saved successfully")
             }
             .addOnFailureListener { error ->
                 onError(error)
+                Log.d("NotificationSetupViewModel", "Notification setup save failed: $error")
             }
     }
 }

--- a/app/src/main/java/com/will/busnotification/viewmodel/SearchLineViewModel.kt
+++ b/app/src/main/java/com/will/busnotification/viewmodel/SearchLineViewModel.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 
 @OptIn(FlowPreview::class)
 @HiltViewModel
-class AddBusViewModel @Inject constructor(
+class SearchLineViewModel @Inject constructor(
     private val placesRepository: PlacesRepository
 ) : ViewModel() {
 


### PR DESCRIPTION
## Resumo
- atualiza `NotificationSettingsCard` para se comportar como um card clicável
- ao tocar no card, abre um `TimePicker` em `AlertDialog`
- exibe e atualiza o horário selecionado no próprio card

## Detalhes técnicos
- adiciona estado local para `selectedHour`, `selectedMinute` e controle de exibição do dialog
- substitui o conteúdo anterior do card por um foco único na escolha de horário
- cria composable privado `TimePickerDialog` para encapsular o seletor e ações de confirmar/cancelar

## Validação
- tentativa de compilação com `./gradlew :app:compileDebugKotlin` (falhou por bloqueio de download do Gradle wrapper via proxy 403)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a62e864cd48325a1e5f2573626e8e3)