### PR TITLE
ci: automatiza geração e publicação da release de APK

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,29 +2,41 @@ name: Android CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Decode google-services.json
-      run: |
-        echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > app/google-services.json
+      - uses: actions/checkout@v4
 
-    - name: set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: gradle
+      - name: Prepare Firebase config
+        shell: bash
+        run: |
+          set -euo pipefail
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build
+          if [[ -n "${{ secrets.GOOGLE_SERVICES_JSON }}" ]]; then
+            echo "Decoding google-services.json from secret"
+            echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > app/google-services.json
+          elif [[ -f app/google-services.json ]]; then
+            echo "Using repository google-services.json"
+          else
+            echo "::error::Missing Firebase config. Configure GOOGLE_SERVICES_JSON secret with base64(app/google-services.json)."
+            exit 1
+          fi
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew --no-daemon build

--- a/.github/workflows/publish-apk.yml
+++ b/.github/workflows/publish-apk.yml
@@ -1,13 +1,16 @@
-name: Build and publish APK
+name: Build and publish APK release
 
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
+  workflow_dispatch:
 
 permissions:
   contents: write
+
+concurrency:
+  group: apk-release-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-publish:
@@ -16,28 +19,49 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Java 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: "17"
+          cache: gradle
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build debug APK
-        run: ./gradlew assembleDebug
-
-      - name: Copy APK to stable download path
+      - name: Prepare Firebase config
+        shell: bash
         run: |
-          mkdir -p app/release
-          cp app/build/outputs/apk/debug/app-debug.apk app/release/app-release.apk
+          set -euo pipefail
 
-      - name: Commit APK to repository
-        uses: stefanzweifel/git-auto-commit-action@v5
+          if [[ -n "${{ secrets.GOOGLE_SERVICES_JSON }}" ]]; then
+            echo "Decoding google-services.json from secret"
+            echo "${{ secrets.GOOGLE_SERVICES_JSON }}" | base64 --decode > app/google-services.json
+          elif [[ -f app/google-services.json ]]; then
+            echo "Using repository google-services.json"
+          else
+            echo "::error::Missing Firebase config. Configure GOOGLE_SERVICES_JSON secret with base64(app/google-services.json)."
+            exit 1
+          fi
+
+      - name: Build APK
+        run: ./gradlew --no-daemon clean assembleDebug
+
+      - name: Prepare release asset
+        run: |
+          mkdir -p release-assets
+          cp app/build/outputs/apk/debug/app-debug.apk release-assets/app-release.apk
+
+      - name: Publish/Update latest release
+        uses: ncipollo/release-action@v1
         with:
-          commit_message: 'ci: update downloadable APK [skip ci]'
-          file_pattern: app/release/app-release.apk
+          tag: latest
+          name: Latest APK
+          body: |
+            APK mais recente gerado automaticamente pelo workflow.
+            Commit: ${{ github.sha }}
+          artifacts: release-assets/app-release.apk
+          allowUpdates: true
+          replacesArtifacts: true
+          makeLatest: true

--- a/APK_DOWNLOAD.md
+++ b/APK_DOWNLOAD.md
@@ -1,21 +1,34 @@
-# Download do APK via Internet
+# Download do APK via GitHub Releases
 
-Este repositório agora possui uma GitHub Action para gerar um APK e publicar em um caminho fixo no branch.
+Este repositório possui uma GitHub Action para gerar o APK automaticamente e publicar na **release `latest`**.
 
-## Como gerar
+## Como funciona
 
-1. Vá em **Actions** no GitHub.
-2. Execute o workflow **Build and publish APK** manualmente.
-3. Ao final, ele salva o arquivo em `app/release/app-release.apk` no branch atual.
+- O workflow `Build and publish APK release` roda automaticamente em cada push na `main`.
+- Também pode ser executado manualmente pelo botão **Run workflow** em **Actions**.
+- Ao final, ele atualiza a release `latest` com o arquivo `app-release.apk`.
 
-## URL de download
+## URL fixa de download
 
-Depois da execução, você poderá baixar em:
+Use sempre esta URL (sem trocar owner/repo):
 
-`https://raw.githubusercontent.com/<OWNER>/<REPO>/<BRANCH>/app/release/app-release.apk`
+`https://github.com/<OWNER>/<REPO>/releases/download/latest/app-release.apk`
 
-Exemplo de formato:
+Exemplo:
 
-`https://raw.githubusercontent.com/Luminary-Team/eden-mobile/refs/heads/main/app/release/app-release.apk`
+`https://github.com/Luminary-Team/eden-mobile/releases/download/latest/app-release.apk`
 
-> Observação: o workflow gera a variante **debug** (`assembleDebug`) para garantir instalação fácil sem configuração de assinatura de release.
+## Pré-requisito obrigatório
+
+Se o projeto usa Firebase e o arquivo `app/google-services.json` não está versionado, configure o secret:
+
+- Nome: `GOOGLE_SERVICES_JSON`
+- Valor: conteúdo **base64** do arquivo `app/google-services.json`
+
+Gerar base64 localmente:
+
+```bash
+base64 -w 0 app/google-services.json
+```
+
+> Observação: o workflow gera a variante **debug** (`assembleDebug`) para não depender de assinatura de release.


### PR DESCRIPTION
### Motivation
- Garantir que a geração e publicação do APK na `main` seja totalmente automatizada e executável sem intervenção manual.
- Evitar commitar artefatos binários no repositório e oferecer uma URL de download estável.
- Tornar o pipeline resiliente quando o arquivo `app/google-services.json` não estiver versionado, exigindo um secret claro quando necessário.

### Description
- Atualizei `.github/workflows/publish-apk.yml` para publicar o APK como asset na release `latest` usando `ncipollo/release-action@v1` em vez de commitar o binário no branch. 
- Adicionei `workflow_dispatch` e `concurrency` ao workflow de publicação, e passei a gerar `app-release.apk` copiando o `assembleDebug` para `release-assets` antes do upload. 
- Dei robustez ao preparo do `google-services.json` em ambos workflows (`.github/workflows/publish-apk.yml` e `.github/workflows/android.yml`): se existir o secret `GOOGLE_SERVICES_JSON` ele é decodificado, caso contrário o job usa o arquivo versionado ou falha com mensagem explicativa. 
- Atualizei `APK_DOWNLOAD.md` com instruções sobre o novo fluxo (download via release `latest`) e como criar o secret `GOOGLE_SERVICES_JSON` com `base64 -w 0 app/google-services.json`.

### Testing
- Executei `./gradlew --version` para validar a ferramenta Gradle disponível, e a verificação foi bem-sucedida. 
- Tentei validar a sintaxe YAML com um script Python que usa `yaml.safe_load`, porém o ambiente não tinha `PyYAML` instalado então essa validação não foi executada. 
- Não foi executado o build completo (`assembleDebug`) localmente neste ambiente; o workflow contém `./gradlew --no-daemon clean assembleDebug` que será exercitado no GitHub Actions quando o secret estiver configurado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8f5a8fc6c8325840a0869250c5541)