### PR TITLE
Usar horário local atual em RouteRequest.departureTime

### DIFF
--- a/app/src/main/java/com/will/busnotification/data/dto/RouteRequest.kt
+++ b/app/src/main/java/com/will/busnotification/data/dto/RouteRequest.kt
@@ -1,6 +1,7 @@
 package com.will.busnotification.data.dto
 
-import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
 
 /**
  * Requisição para a Google Routes API
@@ -14,7 +15,9 @@ data class RouteRequest(
     val origin: AdressRequest,
     val destination: AdressRequest,
     val travelMode: String = "TRANSIT",
-    val departureTime: String? = "${LocalDate.now()}T8:00:00Z",
+    val departureTime: String? = OffsetDateTime.now()
+        .withNano(0)
+        .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
     val computeAlternativeRoutes: Boolean = true,
     val transitPreferences: TransitPreferences? = null
 )


### PR DESCRIPTION
### Motivation
- Fazer com que a requisição para a Google Routes API use o horário atual (agora) ao calcular o próximo ônibus em vez de um horário fixo `08:00:00Z`.

### Description
- Atualizei `app/src/main/java/com/will/busnotification/data/dto/RouteRequest.kt` para usar `OffsetDateTime.now().withNano(0).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)` como valor padrão de `departureTime` e ajustei os imports para `OffsetDateTime` e `DateTimeFormatter`.

### Testing
- Executei `./gradlew testDebugUnitTest` que não completou no ambiente devido a uma limitação/tooling do Android SDK (`25.0.1`), portanto os testes unitários não puderam ser validados aqui.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac9733b8d48325a5c1ac19e71f1230)