### PR TITLE
feat: usar localização real do dispositivo como origem e remover mocks

### DIFF
--- a/app/src/main/java/com/will/busnotification/data/dto/AdressRequest.kt
+++ b/app/src/main/java/com/will/busnotification/data/dto/AdressRequest.kt
@@ -1,5 +1,30 @@
 package com.will.busnotification.data.dto
 
+/**
+ * Waypoint for the Google Routes API.
+ * Accepts either a textual [address] OR a [location] with lat/lng coordinates.
+ * When both are provided the API prefers [location].
+ */
 data class AdressRequest(
-    val address: String,
+    val address: String? = null,
+    val location: LatLngWrapper? = null,
+) {
+    companion object {
+        /** Create a waypoint from a textual address. */
+        fun fromAddress(address: String) = AdressRequest(address = address)
+
+        /** Create a waypoint from latitude/longitude coordinates. */
+        fun fromLatLng(lat: Double, lng: Double) = AdressRequest(
+            location = LatLngWrapper(latLng = LatLngCoord(latitude = lat, longitude = lng))
+        )
+    }
+}
+
+data class LatLngWrapper(
+    val latLng: LatLngCoord
+)
+
+data class LatLngCoord(
+    val latitude: Double,
+    val longitude: Double
 )

--- a/app/src/main/java/com/will/busnotification/repository/PlacesRepositoryImpl.kt
+++ b/app/src/main/java/com/will/busnotification/repository/PlacesRepositoryImpl.kt
@@ -4,9 +4,7 @@ import android.util.Log
 import com.will.busnotification.BuildConfig
 import com.will.busnotification.data.dto.AdressRequest
 import com.will.busnotification.data.dto.DirectionsResponseDto
-import com.will.busnotification.data.dto.PlaceResult
 import com.will.busnotification.data.dto.RouteRequest
-import com.will.busnotification.data.dto.TransitDetailsDto
 import com.will.busnotification.data.dto.TransitPreferences
 import com.will.busnotification.data.mapper.toTransitSegments
 import com.will.busnotification.data.model.TransitSegment
@@ -23,19 +21,14 @@ class PlacesRepositoryImpl @Inject constructor(
     override suspend fun searchPlaces(query: String): List<TransitSegment> {
         val apiKey = BuildConfig.GOOGLE_API_KEY
 
-        val loc = try {
-            locationProvider.getLastKnownLocation()
-        } catch (_: Throwable) {
-            null
-        }
+        val origin = resolveOrigin()
+            ?: throw IllegalStateException(
+                "Não foi possível obter a localização atual. Verifique se a permissão de localização foi concedida."
+            )
 
         val request = RouteRequest(
-            origin = (
-                    AdressRequest("Rua são ladislau, 141")
-            ),
-            destination = (
-                    AdressRequest(query)
-            ),
+            origin = origin,
+            destination = AdressRequest.fromAddress(query),
             travelMode = "TRANSIT",
             computeAlternativeRoutes = true,
             transitPreferences = TransitPreferences(
@@ -45,7 +38,8 @@ class PlacesRepositoryImpl @Inject constructor(
         )
 
         try {
-            val response: DirectionsResponseDto = apiService.searchPlaces(apiKey = apiKey, request = request)
+            val response: DirectionsResponseDto =
+                apiService.searchPlaces(apiKey = apiKey, request = request)
             return response.toTransitSegments()
         } catch (e: HttpException) {
             val errBody = try {
@@ -58,6 +52,26 @@ class PlacesRepositoryImpl @Inject constructor(
         } catch (e: IOException) {
             Log.e("PlacesRepository", "Network I/O error", e)
             throw e
+        }
+    }
+
+    /**
+     * Tries to resolve the user's current location as a Routes API origin.
+     * Prefers GPS coordinates; falls back to null if unavailable.
+     */
+    private fun resolveOrigin(): AdressRequest? {
+        return try {
+            val loc = locationProvider.getLastKnownLocation()
+            if (loc != null) {
+                Log.d("PlacesRepository", "Using device location: ${loc.latitude}, ${loc.longitude}")
+                AdressRequest.fromLatLng(loc.latitude, loc.longitude)
+            } else {
+                Log.w("PlacesRepository", "Location unavailable — getLastKnownLocation returned null")
+                null
+            }
+        } catch (e: Throwable) {
+            Log.e("PlacesRepository", "Failed to get location", e)
+            null
         }
     }
 }

--- a/app/src/main/java/com/will/busnotification/viewmodel/BusViewModel.kt
+++ b/app/src/main/java/com/will/busnotification/viewmodel/BusViewModel.kt
@@ -11,6 +11,7 @@ import com.will.busnotification.data.dto.RouteRequest
 import com.will.busnotification.data.dto.TransitPreferences
 import com.will.busnotification.data.model.TransitSegment
 import com.will.busnotification.data.network.GooglePlacesApiService
+import com.will.busnotification.repository.LocationProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,7 +23,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class BusViewModel @Inject constructor(
-    private val apiService: GooglePlacesApiService
+    private val apiService: GooglePlacesApiService,
+    private val locationProvider: LocationProvider
 ) : ViewModel() {
 
     private val _busList = MutableStateFlow<List<TransitSegment>>(emptyList())
@@ -43,6 +45,14 @@ class BusViewModel @Inject constructor(
             Log.d(TAG, "=== INICIANDO CARREGAMENTO DOS ÔNIBUS SALVOS ===")
 
             try {
+                // Resolve the user's current location to use as origin
+                val origin = resolveCurrentOrigin()
+                if (origin == null) {
+                    Log.w(TAG, "⚠ Localização atual indisponível — não é possível calcular rotas.")
+                    _busList.value = emptyList()
+                    return@launch
+                }
+
                 val snapshot = firestore.collection("locations").get().await()
                 val documents = snapshot.documents
                 Log.d(TAG, "Total de ônibus salvos no Firestore: ${documents.size}")
@@ -57,21 +67,19 @@ class BusViewModel @Inject constructor(
 
                 for (doc in documents) {
                     val lineCode = doc.getString("lineCode") ?: doc.id
-                    val departureStop = doc.getString("departureStop") ?: ""
-                    val destination = ("Terminal" + doc.getString("destination"))
+                    val destination = doc.getString("destination") ?: ""
 
                     Log.d(TAG, "--- Processando linha: $lineCode ---")
-                    Log.d(TAG, "  Origem (departureStop): '$departureStop'")
                     Log.d(TAG, "  Destino (destination): '$destination'")
 
-                    if (departureStop.isBlank() || destination.isBlank()) {
-                        Log.w(TAG, "  ⚠ Campos obrigatórios ausentes para linha '$lineCode' — pulando.")
+                    if (destination.isBlank()) {
+                        Log.w(TAG, "  ⚠ Destino ausente para linha '$lineCode' — pulando.")
                         continue
                     }
 
                     val request = RouteRequest(
-                        origin = AdressRequest(departureStop),
-                        destination = AdressRequest(destination),
+                        origin = origin,
+                        destination = AdressRequest.fromAddress(destination),
                         travelMode = "TRANSIT",
                         computeAlternativeRoutes = true,
                         transitPreferences = TransitPreferences(
@@ -134,6 +142,25 @@ class BusViewModel @Inject constructor(
             } finally {
                 _isLoading.value = false
             }
+        }
+    }
+
+    /**
+     * Resolves the user's current location into a Routes API origin waypoint.
+     * Returns null if location is unavailable.
+     */
+    private fun resolveCurrentOrigin(): AdressRequest? {
+        return try {
+            val loc = locationProvider.getLastKnownLocation()
+            if (loc != null) {
+                Log.d(TAG, "Using device location: ${loc.latitude}, ${loc.longitude}")
+                AdressRequest.fromLatLng(loc.latitude, loc.longitude)
+            } else {
+                null
+            }
+        } catch (e: Throwable) {
+            Log.e(TAG, "Failed to get location", e)
+            null
         }
     }
 }


### PR DESCRIPTION
## O que faz

Remove valores hardcoded (mocks) das chamadas à Google Routes API e passa a usar a localização real do dispositivo do usuário.

### Mudanças

**`AdressRequest.kt`**
- Estendido para suportar tanto `address` (texto) quanto `location` (latLng via GPS)
- Adicionados factory methods `fromAddress()` e `fromLatLng()` para construção type-safe
- Novos DTOs: `LatLngWrapper` e `LatLngCoord` compatíveis com o schema da Google Routes API

**`PlacesRepositoryImpl.kt`**
- ❌ Removido endereço fixo `"Rua são ladislau, 141"` usado como origin
- ✅ Agora usa `LocationProvider.getLastKnownLocation()` para obter coordenadas GPS reais
- Lança `IllegalStateException` se a localização não estiver disponível (permissão negada ou GPS desligado)

**`BusViewModel.kt`**
- ❌ Removido prefixo `"Terminal"` hardcoded concatenado antes do destination
- ✅ Injeta `LocationProvider` via Hilt para acesso à localização do dispositivo
- ✅ Usa coordenadas GPS reais como origin nas chamadas à API
- Trata cenário de localização indisponível com log e lista vazia
- Removida dependência do campo `departureStop` do Firestore (origin agora é sempre a posição atual)

## Por quê

O app estava usando um endereço fixo como ponto de origem em todas as buscas de rotas, o que fazia com que os resultados fossem irrelevantes para qualquer usuário que não estivesse naquele endereço específico. Além disso, o prefixo `"Terminal"` era concatenado ao destino, o que corrompía a busca.

## Como testar

1. Garantir que a permissão de localização está concedida
2. Abrir o app e verificar que a tela inicial carrega ônibus baseados na localização real
3. Na tela de busca (SearchLineScreen), pesquisar um destino e confirmar que as rotas partem da posição atual
4. Verificar nos logs (`BusViewModel`/`PlacesRepository`) que as coordenadas GPS estão sendo usadas