### PR TITLE
fix: redesenhar tela de busca e corrigir resultados vazios

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icons.extended)
     implementation(libs.retrofit)
     implementation(libs.converter.gson)
     implementation(libs.androidx.media3.common.ktx)

--- a/app/src/main/java/com/will/busnotification/repository/PlacesRepository.kt
+++ b/app/src/main/java/com/will/busnotification/repository/PlacesRepository.kt
@@ -3,5 +3,10 @@ package com.will.busnotification.repository
 import com.will.busnotification.data.model.TransitSegment
 
 interface PlacesRepository {
+    /**
+     * Search for transit routes to [query] destination.
+     * Returns a list of transit segments found, or empty if no routes available.
+     * May throw IOException on network errors or IllegalStateException if location is unavailable.
+     */
     suspend fun searchPlaces(query: String): List<TransitSegment>
 }

--- a/app/src/main/java/com/will/busnotification/repository/PlacesRepositoryImpl.kt
+++ b/app/src/main/java/com/will/busnotification/repository/PlacesRepositoryImpl.kt
@@ -18,6 +18,10 @@ class PlacesRepositoryImpl @Inject constructor(
     private val locationProvider: LocationProvider
 ) : PlacesRepository {
 
+    companion object {
+        private const val TAG = "PlacesRepository"
+    }
+
     override suspend fun searchPlaces(query: String): List<TransitSegment> {
         val apiKey = BuildConfig.GOOGLE_API_KEY
 
@@ -26,15 +30,62 @@ class PlacesRepositoryImpl @Inject constructor(
                 "Não foi possível obter a localização atual. Verifique se a permissão de localização foi concedida."
             )
 
-        val request = RouteRequest(
+        // 1st attempt: BUS only
+        val busResults = fetchRoutes(
+            apiKey = apiKey,
             origin = origin,
             destination = AdressRequest.fromAddress(query),
+            allowedModes = listOf("BUS")
+        )
+
+        if (busResults.isNotEmpty()) {
+            Log.d(TAG, "Found ${busResults.size} BUS-only results for '$query'")
+            return busResults
+        }
+
+        // 2nd attempt: any TRANSIT mode (bus + metro + train + tram)
+        Log.d(TAG, "No BUS-only results for '$query' — retrying with all transit modes")
+        val allTransitResults = fetchRoutes(
+            apiKey = apiKey,
+            origin = origin,
+            destination = AdressRequest.fromAddress(query),
+            allowedModes = null // no filter → accepts bus, metro, train, tram
+        )
+
+        if (allTransitResults.isNotEmpty()) {
+            Log.d(TAG, "Found ${allTransitResults.size} results with all transit modes for '$query'")
+        } else {
+            Log.w(TAG, "No transit results at all for '$query'")
+        }
+
+        return allTransitResults
+    }
+
+    /**
+     * Calls the Google Routes API with the given parameters.
+     * @param allowedModes if null, no filter is applied (all transit modes)
+     */
+    private suspend fun fetchRoutes(
+        apiKey: String,
+        origin: AdressRequest,
+        destination: AdressRequest,
+        allowedModes: List<String>?
+    ): List<TransitSegment> {
+        val transitPrefs = if (allowedModes != null) {
+            TransitPreferences(
+                routingPreference = "TRANSIT_ROUTING_PREFERENCE_UNSPECIFIED",
+                allowedTravelModes = allowedModes
+            )
+        } else {
+            null
+        }
+
+        val request = RouteRequest(
+            origin = origin,
+            destination = destination,
             travelMode = "TRANSIT",
             computeAlternativeRoutes = true,
-            transitPreferences = TransitPreferences(
-                routingPreference = "TRANSIT_ROUTING_PREFERENCE_UNSPECIFIED",
-                allowedTravelModes = listOf("BUS")
-            )
+            transitPreferences = transitPrefs
         )
 
         try {
@@ -47,10 +98,10 @@ class PlacesRepositoryImpl @Inject constructor(
             } catch (_: Throwable) {
                 "<failed to read error body>"
             }
-            Log.e("PlacesRepository", "HttpException (${e.code()}): $errBody", e)
+            Log.e(TAG, "HttpException (${e.code()}): $errBody", e)
             throw e
         } catch (e: IOException) {
-            Log.e("PlacesRepository", "Network I/O error", e)
+            Log.e(TAG, "Network I/O error", e)
             throw e
         }
     }
@@ -63,14 +114,14 @@ class PlacesRepositoryImpl @Inject constructor(
         return try {
             val loc = locationProvider.getLastKnownLocation()
             if (loc != null) {
-                Log.d("PlacesRepository", "Using device location: ${loc.latitude}, ${loc.longitude}")
+                Log.d(TAG, "Using device location: ${loc.latitude}, ${loc.longitude}")
                 AdressRequest.fromLatLng(loc.latitude, loc.longitude)
             } else {
-                Log.w("PlacesRepository", "Location unavailable — getLastKnownLocation returned null")
+                Log.w(TAG, "Location unavailable — getLastKnownLocation returned null")
                 null
             }
         } catch (e: Throwable) {
-            Log.e("PlacesRepository", "Failed to get location", e)
+            Log.e(TAG, "Failed to get location", e)
             null
         }
     }

--- a/app/src/main/java/com/will/busnotification/ui/SearchLineScreen.kt
+++ b/app/src/main/java/com/will/busnotification/ui/SearchLineScreen.kt
@@ -1,6 +1,11 @@
 package com.will.busnotification.ui
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,36 +14,49 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.outlined.DirectionsBus
+import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.SearchOff
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SearchBar
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.will.busnotification.data.model.TransitSegment
 import com.will.busnotification.ui.components.HeaderComponent
 import com.will.busnotification.viewmodel.SearchLineViewModel
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
-@OptIn(ExperimentalMaterial3Api::class)
+private val BluePrimary = Color(0xFF5B8FCF)
+private val BlueLight = Color(0xFFE0EAFC)
+
 @Composable
 fun SearchLineScreen(
     navController: NavHostController,
@@ -47,81 +65,299 @@ fun SearchLineScreen(
     val searchQuery by viewModel.searchQuery.collectAsState()
     val searchResults by viewModel.searchResults.collectAsState()
     val isSearching by viewModel.isSearching.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
+    val emptyResults by viewModel.emptyResults.collectAsState()
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF6F8FC))
+    ) {
         HeaderComponent(
             text = "Adicionar Notificação",
             hasBack = true,
             onBackClick = { navController.popBackStack() }
         )
 
-
-        SearchBar(
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            query = searchQuery,
-            onQueryChange = viewModel::onSearchQueryChange,
-            onSearch = {},
-            active = searchResults.isNotEmpty() || searchQuery.isNotBlank(),
-            onActiveChange = { },
-            leadingIcon = { Icon(Icons.Default.Search, contentDescription = "Pesquisar") },
-            placeholder = { Text("Digite o destino") }
+                .fillMaxSize()
+                .padding(horizontal = 20.dp, vertical = 16.dp)
         ) {
-            if (isSearching) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
+            // --- Search field ---
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = viewModel::onSearchQueryChange,
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = {
+                    Text(
+                        text = "Digite o destino (ex: Terminal Lapa)",
+                        color = Color.Gray
+                    )
+                },
+                leadingIcon = {
+                    Icon(
+                        Icons.Default.Search,
+                        contentDescription = "Pesquisar",
+                        tint = BluePrimary
+                    )
+                },
+                trailingIcon = {
+                    if (isSearching) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                            color = BluePrimary
+                        )
+                    }
+                },
+                singleLine = true,
+                shape = RoundedCornerShape(16.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = BluePrimary,
+                    unfocusedBorderColor = Color(0xFFD0D5DD),
+                    focusedContainerColor = Color.White,
+                    unfocusedContainerColor = Color.White
+                )
+            )
+
+            // --- Hint text ---
+            AnimatedVisibility(
+                visible = searchQuery.isBlank(),
+                enter = fadeIn(),
+                exit = fadeOut()
+            ) {
+                Text(
+                    text = "Busque pelo nome do destino para encontrar linhas de ônibus disponíveis",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray,
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // --- Content area ---
+            when {
+                // Loading state (only when no results yet)
+                isSearching && searchResults.isEmpty() -> {
+                    LoadingState()
                 }
-            } else {
-                LazyColumn(modifier = Modifier.padding(horizontal = 16.dp)) {
-                    items(searchResults) { place ->
-                        Card(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 6.dp)
-                                .clickable {
-                                    val encodedLineName = URLEncoder.encode(place.lineName, StandardCharsets.UTF_8.toString())
-                                    val encodedDepartureStop = URLEncoder.encode(place.departureStop, StandardCharsets.UTF_8.toString())
-                                    val encodedArrivalStop = URLEncoder.encode(place.arrivalStop, StandardCharsets.UTF_8.toString())
-                                    navController.navigate("notificationSetup/${place.lineCode}/$encodedLineName/$encodedDepartureStop/$encodedArrivalStop/${place.arrivalTime}/${place.headsign}")
-                                },
-                            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-                            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-                        ) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.LocationOn,
-                                    contentDescription = "Ícone de localização",
-                                    modifier = Modifier.padding(end = 12.dp)
-                                )
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(text = place.lineCode, fontWeight = FontWeight.Bold)
-                                    Spacer(modifier = Modifier.height(4.dp))
-                                    Text(text = place.lineName.split("/").first(), fontWeight = FontWeight.SemiBold)
+
+                // Error state
+                errorMessage != null -> {
+                    StatusMessage(
+                        icon = Icons.Outlined.ErrorOutline,
+                        title = "Ops!",
+                        message = errorMessage!!,
+                        iconTint = Color(0xFFD32F2F)
+                    )
+                }
+
+                // Empty results after search
+                emptyResults -> {
+                    StatusMessage(
+                        icon = Icons.Outlined.SearchOff,
+                        title = "Nenhuma rota encontrada",
+                        message = "Tente um destino diferente ou mais específico. Ex: \"Terminal Lapa\" ou \"Shopping Eldorado\"",
+                        iconTint = Color(0xFFFF9800)
+                    )
+                }
+
+                // Search results
+                searchResults.isNotEmpty() -> {
+                    Text(
+                        text = "${searchResults.size} linha${if (searchResults.size > 1) "s" else ""} encontrada${if (searchResults.size > 1) "s" else ""}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = Color.Gray,
+                        modifier = Modifier.padding(bottom = 8.dp, start = 4.dp)
+                    )
+
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        items(searchResults) { segment ->
+                            BusResultCard(
+                                segment = segment,
+                                onClick = {
+                                    val enc = { s: String ->
+                                        URLEncoder.encode(s, StandardCharsets.UTF_8.toString())
+                                    }
+                                    navController.navigate(
+                                        "notificationSetup/${segment.lineCode}/${enc(segment.lineName)}/${enc(segment.departureStop)}/${enc(segment.arrivalStop)}/${segment.arrivalTime}/${segment.headsign}"
+                                    )
                                 }
-                            }
+                            )
                         }
                     }
                 }
+
+                // Initial state — nothing searched yet
+                searchQuery.isBlank() -> {
+                    StatusMessage(
+                        icon = Icons.Outlined.DirectionsBus,
+                        title = "Para onde você vai?",
+                        message = "Pesquise seu destino para ver as linhas de ônibus que passam perto de você",
+                        iconTint = BluePrimary
+                    )
+                }
             }
         }
-
-        Spacer(modifier = Modifier.height(20.dp))
-
     }
+}
+
+// ─── Components ─────────────────────────────────────────────────────────
+
+@Composable
+private fun BusResultCard(
+    segment: TransitSegment,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(14.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Line code badge
+            Box(
+                modifier = Modifier
+                    .background(BlueLight, RoundedCornerShape(10.dp))
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = segment.lineCode,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 15.sp,
+                    color = BluePrimary
+                )
+            }
+
+            Spacer(modifier = Modifier.width(14.dp))
+
+            // Route info
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = segment.lineName.split("/").first().trim(),
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = Color(0xFF1A1A2E)
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = "${segment.departureStop} → ${segment.arrivalStop}",
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    color = Color.Gray
+                )
+            }
+
+            // Departure time
+            if (segment.departureTime.isNotBlank()) {
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = formatTime(segment.departureTime),
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 14.sp,
+                        color = BluePrimary
+                    )
+                    Text(
+                        text = "partida",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.Gray
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingState() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 80.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator(color = BluePrimary)
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Buscando rotas...",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.Gray
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusMessage(
+    icon: ImageVector,
+    title: String,
+    message: String,
+    iconTint: Color = BluePrimary
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 60.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(56.dp),
+            tint = iconTint
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = Color(0xFF1A1A2E)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.Gray,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 32.dp)
+        )
+    }
+}
+
+/**
+ * Extract a human-readable time from ISO or time string.
+ * Handles "2026-03-18T14:30:00-03:00" → "14:30"
+ * or already short strings like "14:30".
+ */
+private fun formatTime(raw: String): String {
+    // ISO format: try to extract HH:mm from "...THH:mm:ss..."
+    val tIndex = raw.indexOf('T')
+    if (tIndex != -1 && raw.length >= tIndex + 6) {
+        return raw.substring(tIndex + 1, tIndex + 6)
+    }
+    // Already short enough
+    return if (raw.length >= 5) raw.substring(0, 5) else raw
 }
 
 @Preview(showBackground = true)
 @Composable
 fun SearchLineScreenPreview() {
-    // Nota: O preview não fará chamadas de API reais.
     SearchLineScreen(navController = rememberNavController())
 }

--- a/app/src/main/java/com/will/busnotification/viewmodel/SearchLineViewModel.kt
+++ b/app/src/main/java/com/will/busnotification/viewmodel/SearchLineViewModel.kt
@@ -22,6 +22,12 @@ class SearchLineViewModel @Inject constructor(
     private val placesRepository: PlacesRepository
 ) : ViewModel() {
 
+    companion object {
+        private const val TAG = "SearchLineViewModel"
+        private const val MIN_QUERY_LENGTH = 3
+        private const val DEBOUNCE_MS = 600L
+    }
+
     private val _searchQuery = MutableStateFlow("")
     val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
 
@@ -31,27 +37,51 @@ class SearchLineViewModel @Inject constructor(
     private val _searchResults = MutableStateFlow<List<TransitSegment>>(emptyList())
     val searchResults: StateFlow<List<TransitSegment>> = _searchResults.asStateFlow()
 
+    /** Null = no error; non-null = user-facing error message */
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
+
+    /** True when search completed successfully but returned zero results */
+    private val _emptyResults = MutableStateFlow(false)
+    val emptyResults: StateFlow<Boolean> = _emptyResults.asStateFlow()
+
     init {
         _searchQuery
-            .debounce(500) // Evita chamadas de API a cada letra digitada
+            .debounce(DEBOUNCE_MS)
             .onEach { query ->
-                if (query.isBlank()) {
+                _errorMessage.value = null
+                _emptyResults.value = false
+
+                if (query.isBlank() || query.length < MIN_QUERY_LENGTH) {
                     _searchResults.value = emptyList()
                     _isSearching.value = false
-                } else {
-                    _isSearching.value = true
-                    viewModelScope.launch {
-                        try {
-                            val results = placesRepository.searchPlaces(query)
-                            _searchResults.value = results
-                        } catch (e: Exception) {
-                            Log.e("AddBusViewModel", "searchPlaces failed", e)
-                            _searchResults.value = emptyList()
-                        } finally {
-                            _isSearching.value = false
+                    return@onEach
+                }
+
+                _isSearching.value = true
+                viewModelScope.launch {
+                    try {
+                        val results = placesRepository.searchPlaces(query)
+                        _searchResults.value = results
+                        _emptyResults.value = results.isEmpty()
+
+                        if (results.isEmpty()) {
+                            Log.d(TAG, "No results for query: '$query'")
+                        } else {
+                            Log.d(TAG, "Found ${results.size} results for '$query'")
                         }
+                    } catch (e: IllegalStateException) {
+                        // Location unavailable
+                        Log.e(TAG, "Location error", e)
+                        _searchResults.value = emptyList()
+                        _errorMessage.value = "Localização indisponível. Verifique se o GPS está ativado e a permissão concedida."
+                    } catch (e: Exception) {
+                        Log.e(TAG, "searchPlaces failed", e)
+                        _searchResults.value = emptyList()
+                        _errorMessage.value = "Erro ao buscar rotas. Verifique sua conexão e tente novamente."
+                    } finally {
+                        _isSearching.value = false
                     }
-                    Log.d("Google API response", "${_searchResults.value}")
                 }
             }
             .launchIn(viewModelScope)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 androidx-media3-common-ktx = { group = "androidx.media3", name = "media3-common-ktx", version.ref = "media3CommonKtx" }
 androidx-navigation-compose-android = { group = "androidx.navigation", name = "navigation-compose-android", version.ref = "navigationComposeAndroid" }


### PR DESCRIPTION
## O que faz

Redesenha a tela de busca de linhas (SearchLineScreen) com um layout limpo e corrige o problema intermitente de resultados vazios.

---

## Problema 1: Layout fullscreen

**Antes:** O `SearchBar` do Material3 expandia para tela inteira quando ativado (`active = true`). Isso é o comportamento padrão do M3, mas ficava ruim — o campo de busca sumia junto com o header e a lista ocupava 100% da tela.

**Depois:** Substituído por `OutlinedTextField` + `LazyColumn` inline. O layout agora fica fixo e controlado:
- Campo de busca com borda arredondada (16dp), ícone de busca azul, loading spinner inline
- Cards de resultado com badge da linha, nome da rota, paradas (origem → destino) e horário de partida
- Estados visuais dedicados: loading centralizado, mensagem de erro (vermelho), sem resultados (laranja), estado inicial (azul)
- Background claro `#F6F8FC` com cards brancos
- Hint text com fade animation quando o campo está vazio

## Problema 2: Resultados vazios intermitentes

**Diagnóstico:**
1. `allowedTravelModes = ["BUS"]` filtrava muito agressivamente — se não existia rota de ônibus direto pro destino, retornava zero resultados mesmo tendo rotas de metrô+ônibus
2. Queries curtas (1-2 caracteres) disparavam buscas inúteis na API
3. Erros de localização (GPS off, permissão negada) eram engolidos silenciosamente — o usuário via lista vazia sem entender por quê

**Correções:**
- **Fallback de transit modes:** Primeira tentativa busca só BUS. Se retorna vazio, faz retry automático sem filtro de modo (aceita bus + metrô + trem + tram). Isso aumenta drasticamente a cobertura
- **Minimum query length:** 3 caracteres mínimos antes de disparar a API
- **Debounce:** Aumentado de 500ms → 600ms
- **Error handling diferenciado:** `IllegalStateException` (GPS/permissão) mostra mensagem específica vs erros genéricos de rede
- **Estados `errorMessage` e `emptyResults`:** Expostos via StateFlow no ViewModel para a UI reagir

## Arquivos alterados

| Arquivo | Mudança |
|---------|--------|
| `SearchLineScreen.kt` | Reescrito: TextField + LazyColumn + estados visuais |
| `SearchLineViewModel.kt` | min query, error/empty states, logging |
| `PlacesRepositoryImpl.kt` | Fallback: BUS → all transit modes |
| `PlacesRepository.kt` | KDoc atualizado |
| `build.gradle.kts` | + material-icons-extended |
| `libs.versions.toml` | + material-icons-extended catalog entry |

## Como testar

1. Abrir o app → tela inicial → tocar no "+"
2. **Layout:** Verificar que o campo de busca NÃO expande fullscreen ao digitar
3. **Estado inicial:** Deve mostrar ícone de ônibus + "Para onde você vai?"
4. **Query curta:** Digitar "La" (2 chars) → não deve disparar busca
5. **Query válida:** Digitar "Terminal Lapa" → deve mostrar resultados com cards bonitos
6. **Sem resultados:** Digitar algo improvável como "xyzabc123" → deve mostrar "Nenhuma rota encontrada" com ícone laranja
7. **Fallback transit:** Digitar destino que só tem metrô → deve encontrar resultados (antes retornava vazio)
8. **GPS off:** Desligar GPS → deve mostrar mensagem de erro de localização