### PR TITLE
feat: permissões inteligentes — localização ao abrir, notificação ao salvar

### DIFF
--- a/app/src/main/java/com/will/busnotification/MainActivity.kt
+++ b/app/src/main/java/com/will/busnotification/MainActivity.kt
@@ -1,44 +1,21 @@
 package com.will.busnotification
 
-import android.Manifest
-import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.content.ContextCompat
 import com.will.busnotification.navigation.AppNavHost
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
-    private val notificationPermissionLauncher = registerForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { /* usuário aceitou ou recusou — o sistema cuida do resto */ }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
         enableEdgeToEdge()
-        requestNotificationPermissionIfNeeded()
 
         setContent {
             AppNavHost()
-        }
-    }
-
-    private fun requestNotificationPermissionIfNeeded() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(
-                    this,
-                    Manifest.permission.POST_NOTIFICATIONS
-                ) != PackageManager.PERMISSION_GRANTED
-            ) {
-                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-            }
         }
     }
 }

--- a/app/src/main/java/com/will/busnotification/ui/HomeScreen.kt
+++ b/app/src/main/java/com/will/busnotification/ui/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.will.busnotification.ui
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +22,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -35,6 +39,7 @@ import androidx.navigation.compose.rememberNavController
 import com.will.busnotification.R
 import com.will.busnotification.ui.components.BusItemComponent
 import com.will.busnotification.ui.components.HeaderComponent
+import com.will.busnotification.ui.permissions.RequestLocationPermission
 import com.will.busnotification.viewmodel.BusViewModel
 
 @Composable
@@ -44,8 +49,22 @@ fun HomeScreen(
 ) {
     val buses by viewModel.busList.collectAsState()
 
-    LaunchedEffect(Unit) {
-        viewModel.loadBusFromFirebase()
+    // Track whether location permission has been resolved (granted or denied)
+    var locationPermissionResolved by remember { mutableStateOf(false) }
+    var locationGranted by remember { mutableStateOf(false) }
+
+    // Request location permission on first composition
+    RequestLocationPermission { granted ->
+        locationGranted = granted
+        locationPermissionResolved = true
+        Log.d("HomeScreen", "Location permission ${if (granted) "granted" else "denied"}")
+    }
+
+    // Only load buses after location permission is resolved and granted
+    LaunchedEffect(locationPermissionResolved, locationGranted) {
+        if (locationPermissionResolved && locationGranted) {
+            viewModel.loadBusFromFirebase()
+        }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -79,7 +98,12 @@ fun HomeScreen(
                                 )
                                 Spacer(modifier = Modifier.height(24.dp))
                                 Text(
-                                    text = "Você não adicionou nenhuma notificação ainda",
+                                    text = if (!locationPermissionResolved)
+                                        "Aguardando permissão de localização..."
+                                    else if (!locationGranted)
+                                        "Permissão de localização necessária para buscar ônibus"
+                                    else
+                                        "Você não adicionou nenhuma notificação ainda",
                                     style = MaterialTheme.typography.titleMedium,
                                     fontWeight = FontWeight.SemiBold,
                                     textAlign = TextAlign.Center,
@@ -87,7 +111,10 @@ fun HomeScreen(
                                     modifier = Modifier.padding(horizontal = 16.dp)
                                 )
                                 Text(
-                                    text = "Toque no botão + para começar!",
+                                    text = if (!locationGranted && locationPermissionResolved)
+                                        "Ative a localização nas configurações do app"
+                                    else
+                                        "Toque no botão + para começar!",
                                     style = MaterialTheme.typography.bodyMedium,
                                     textAlign = TextAlign.Center,
                                     color = MaterialTheme.colorScheme.outline,

--- a/app/src/main/java/com/will/busnotification/ui/SetupNotificationScreen.kt
+++ b/app/src/main/java/com/will/busnotification/ui/SetupNotificationScreen.kt
@@ -27,6 +27,8 @@ import com.will.busnotification.ui.components.HeaderComponent
 import com.will.busnotification.ui.components.NotificationSettingsCard
 import com.will.busnotification.ui.components.RemovePointButton
 import com.will.busnotification.ui.components.SaveChangesButton
+import com.will.busnotification.ui.permissions.RequestNotificationPermission
+import com.will.busnotification.ui.permissions.isNotificationPermissionGranted
 import com.will.busnotification.viewmodel.NotificationSetupViewModel
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
@@ -50,6 +52,30 @@ fun SetupNotificationScreen(
     val decodedDestination = destination?.let { URLDecoder.decode(it, StandardCharsets.UTF_8.toString()) }
 
     var selectedWindow by remember { mutableStateOf(NotificationWindow(8, 0, 18, 0)) }
+
+    // Controls whether we should show the notification permission request
+    var requestingNotificationPermission by remember { mutableStateOf(false) }
+
+    // Payload to save after permission is resolved
+    var pendingPayload by remember { mutableStateOf<NotificationSetupPayload?>(null) }
+
+    // When notification permission is requested and resolved, save and navigate
+    if (requestingNotificationPermission && pendingPayload != null) {
+        RequestNotificationPermission { _ ->
+            // Save regardless of whether user granted or denied notification permission.
+            // The save itself is not blocked by notification permission —
+            // notifications just won't show if denied, but data is still saved.
+            pendingPayload?.let { payload ->
+                notificationSetupViewModel.saveNotificationSetup(context, payload)
+            }
+            pendingPayload = null
+            requestingNotificationPermission = false
+
+            navController.navigate("home") {
+                popUpTo("home") { inclusive = true }
+            }
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -86,10 +112,16 @@ fun SetupNotificationScreen(
                         notificationWindow = selectedWindow
                     )
 
-                    notificationSetupViewModel.saveNotificationSetup(context, payload)
-
-                    navController.navigate("home") {
-                        popUpTo("home") { inclusive = true }
+                    if (isNotificationPermissionGranted(context)) {
+                        // Permission already granted — save directly
+                        notificationSetupViewModel.saveNotificationSetup(context, payload)
+                        navController.navigate("home") {
+                            popUpTo("home") { inclusive = true }
+                        }
+                    } else {
+                        // Need to request notification permission first
+                        pendingPayload = payload
+                        requestingNotificationPermission = true
                     }
                 }
             )

--- a/app/src/main/java/com/will/busnotification/ui/permissions/PermissionUtils.kt
+++ b/app/src/main/java/com/will/busnotification/ui/permissions/PermissionUtils.kt
@@ -1,0 +1,123 @@
+package com.will.busnotification.ui.permissions
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+/**
+ * Requests location permission (ACCESS_FINE_LOCATION) at composition time.
+ * Calls [onResult] with true/false when the user responds.
+ *
+ * This is designed to be placed once in the app entry point (e.g. HomeScreen)
+ * so the permission dialog shows as soon as the user opens the app.
+ */
+@Composable
+fun RequestLocationPermission(
+    onResult: (granted: Boolean) -> Unit = {}
+) {
+    val context = LocalContext.current
+
+    val alreadyGranted = remember {
+        ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    if (alreadyGranted) {
+        LaunchedEffect(Unit) { onResult(true) }
+        return
+    }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val fine = permissions[Manifest.permission.ACCESS_FINE_LOCATION] ?: false
+        val coarse = permissions[Manifest.permission.ACCESS_COARSE_LOCATION] ?: false
+        onResult(fine || coarse)
+    }
+
+    LaunchedEffect(Unit) {
+        launcher.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        )
+    }
+}
+
+/**
+ * Requests POST_NOTIFICATIONS permission (Android 13+).
+ * On older versions, calls [onResult] with true immediately.
+ *
+ * This should NOT be called at app startup — only when the user actually needs notifications
+ * (i.e., when saving their first bus notification).
+ */
+@Composable
+fun RequestNotificationPermission(
+    onResult: (granted: Boolean) -> Unit = {}
+) {
+    val context = LocalContext.current
+
+    // Pre-Tiramisu: notifications always allowed
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        LaunchedEffect(Unit) { onResult(true) }
+        return
+    }
+
+    val alreadyGranted = remember {
+        ContextCompat.checkSelfPermission(
+            context, Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    if (alreadyGranted) {
+        LaunchedEffect(Unit) { onResult(true) }
+        return
+    }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        onResult(granted)
+    }
+
+    LaunchedEffect(Unit) {
+        launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
+}
+
+/**
+ * Utility to check if notification permission is currently granted.
+ */
+fun isNotificationPermissionGranted(context: android.content.Context): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        ContextCompat.checkSelfPermission(
+            context, Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+    } else {
+        true // Pre-13 doesn't need runtime permission
+    }
+}
+
+/**
+ * Utility to check if location permission is currently granted.
+ */
+fun isLocationPermissionGranted(context: android.content.Context): Boolean {
+    return ContextCompat.checkSelfPermission(
+        context, Manifest.permission.ACCESS_FINE_LOCATION
+    ) == PackageManager.PERMISSION_GRANTED ||
+    ContextCompat.checkSelfPermission(
+        context, Manifest.permission.ACCESS_COARSE_LOCATION
+    ) == PackageManager.PERMISSION_GRANTED
+}


### PR DESCRIPTION
## O que faz

Redesenha o fluxo de permissões do app para ser contextual e não intrusivo.

---

## Antes

- `POST_NOTIFICATIONS` era pedido **logo no `onCreate`** da `MainActivity`, antes do usuário ver qualquer coisa — mesmo que ele nunca fosse salvar um ônibus
- `ACCESS_FINE_LOCATION` estava **declarado no manifest mas nunca era pedido em runtime** — o `LocationProvider.getLastKnownLocation()` falhava silenciosamente com `SecurityException` e retornava `null`, fazendo a busca não funcionar

## Depois

### 📍 Localização — pedida ao abrir o app
- `RequestLocationPermission` composable na `HomeScreen` pede `ACCESS_FINE_LOCATION` + `ACCESS_COARSE_LOCATION` assim que o app abre
- Ônibus só carregam do Firebase **após** a permissão ser concedida
- Mensagens contextuais no empty state:
  - Permissão pendente: "Aguardando permissão de localização..."
  - Permissão negada: "Permissão de localização necessária" + "Ative nas configurações"
  - Sem ônibus salvos: mensagem original

### 🔔 Notificação — pedida ao salvar o primeiro ônibus
- **NÃO** é mais pedida no `onCreate`
- Pedida apenas no `SetupNotificationScreen` quando o usuário toca "Salvar"
- Se já tem permissão → salva direto
- Se não tem → pede permissão → salva **independente da resposta** (dados não são bloqueados, só notificações que não vão aparecer se negado)
- Em usos subsequentes, a permissão já foi concedida (ou negada) e não pede de novo

## Arquivos

| Arquivo | Mudança |
|---------|--------|
| `MainActivity.kt` | Removido `requestNotificationPermissionIfNeeded()` e launcher. Só `setContent` |
| `HomeScreen.kt` | + `RequestLocationPermission`, carrega buses só após permissão, mensagens contextuais |
| `SetupNotificationScreen.kt` | Pede `POST_NOTIFICATIONS` no save se necessário, fluxo com `pendingPayload` |
| `ui/permissions/PermissionUtils.kt` | **NOVO** — composables `RequestLocationPermission`, `RequestNotificationPermission`, utils |

## Fluxo visual

```
App abre
  → HomeScreen
    → 📍 Pede localização
    → [Concedida] → Carrega ônibus do Firebase
    → [Negada] → Mostra mensagem orientando

Usuário toca + → SearchLine → Escolhe destino → SetupNotification
  → Toca "Salvar"
    → [Tem permissão de notificação?]
      → SIM → Salva direto
      → NÃO → 🔔 Pede permissão → Salva (aceite ou recusa)
```

## Como testar

### Localização
1. Desinstalar o app (limpar permissões)
2. Instalar e abrir → deve aparecer dialog pedindo localização
3. Conceder → ônibus salvos devem carregar
4. Negar → mensagem "Permissão de localização necessária"

### Notificação
1. Abrir app → **NÃO** deve pedir permissão de notificação
2. Tocar + → buscar destino → escolher linha → tela de setup
3. Tocar "Salvar" → **agora sim** deve pedir permissão de notificação
4. Conceder ou negar → deve salvar e voltar pra home
5. Salvar outro ônibus → não deve pedir de novo (já foi respondido)